### PR TITLE
:password_expired is not executed

### DIFF
--- a/lib/devise_account_expireable/model.rb
+++ b/lib/devise_account_expireable/model.rb
@@ -3,7 +3,7 @@ module Devise
     # Allow for expiration date on Devise resources. Adds attribute:
 
     # * expires_at
-    
+
     module AccountExpireable
       extend  ActiveSupport::Concern
 
@@ -52,6 +52,29 @@ module Devise
 
       def inactive_message
         expired? ? :account_expired : super
+      end
+
+      # Overwrites valid_for_authentication? from Devise::Models::Authenticatable
+      # for verifying whether a user is allowed to sign in or not. If the user
+      # is locked, it should never be allowed.
+      def valid_for_authentication?
+        if super && !expired?
+          true
+        else
+          false
+        end
+      end
+
+      def unauthenticated_message
+        # If set to paranoid mode, do not show the locked message because it
+        # leaks the existence of an account.
+        if Devise.paranoid
+          super
+        elsif expired?
+          :account_expired
+        else
+          super
+        end
       end
     end
   end


### PR DESCRIPTION
* It was not showing proper message [:password_expired]. It has been fixed.