### PR TITLE
Update gem to be compatible with Rails 5 and Devise 4.8

### DIFF
--- a/devise_account_expireable.gemspec
+++ b/devise_account_expireable.gemspec
@@ -2,11 +2,12 @@
 require File.expand_path('../lib/devise_account_expireable/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Justin McNally", "Brendten Eickstaedt"]
-  gem.email         = ["justin@kohactive.com", "brendten@brendteneickstaedt.com"]
+  gem.authors       = ["Justin McNally", "Brendten Eickstaedt", "Toby Chin"]
+  gem.email         = ["justin@kohactive.com", "brendten@brendteneickstaedt.com", "chin.toby@gmail.com"]
   gem.description   = %q{Expire a user's account at a certain date}
   gem.summary       = %q{At a certain date make a user's account not work}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/tobychin/devise_account_expireable"
+  gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
@@ -15,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = DeviseAccountExpireable::VERSION
 
-  gem.add_dependency(%q<devise>, [">= 2.0.4"])
-  gem.add_dependency(%q<rails>, [">= 3.2"])
+  gem.add_dependency(%q<devise>, ["~> 4.8.0"])
+  gem.add_dependency(%q<rails>, ["~> 5.2"])
 end

--- a/devise_account_expireable.gemspec
+++ b/devise_account_expireable.gemspec
@@ -2,11 +2,11 @@
 require File.expand_path('../lib/devise_account_expireable/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Justin McNally", "Brendten Eickstaedt", "Toby Chin"]
-  gem.email         = ["justin@kohactive.com", "brendten@brendteneickstaedt.com", "chin.toby@gmail.com"]
+  gem.authors       = ["Justin McNally", "Brendten Eickstaedt"]
+  gem.email         = ["justin@kohactive.com", "brendten@brendteneickstaedt.com"]
   gem.description   = %q{Expire a user's account at a certain date}
   gem.summary       = %q{At a certain date make a user's account not work}
-  gem.homepage      = "https://github.com/tobychin/devise_account_expireable"
+  gem.homepage      = "https://github.com/j-mcnally/devise_account_expireable"
   gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($\)

--- a/lib/devise_account_expireable/version.rb
+++ b/lib/devise_account_expireable/version.rb
@@ -1,3 +1,3 @@
 module DeviseAccountExpireable
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/lib/generators/devise_account_expireable/devise_account_expireable_generator.rb
+++ b/lib/generators/devise_account_expireable/devise_account_expireable_generator.rb
@@ -6,7 +6,7 @@ class DeviseAccountExpireableGenerator < Rails::Generators::Base
   desc "Generates a migration to add required field to devise account model."
 
   def self.source_root
-    @_devise_source_root ||= File.expand_path("../templates", __FILE__)
+    @_devise_source_root ||= File.expand_path("../", __FILE__)
   end
 
   def self.orm_has_migration?
@@ -31,12 +31,10 @@ class DeviseAccountExpireableGenerator < Rails::Generators::Base
 
     @model_name = model_name.camelize.singularize
 
-
-
     if colum_exists?
       say "* Colum exists on model already exists."
     else
-      migration_template 'migration.rb', "db/migrate/devise_update_#{model_name.downcase}_expire_fields.rb"
+      generate(:migration, "AddExpiresAtTo#{@model_name}", "expires_at:datetime")
     end
 
     puts "Make sure to add :account_expireable to the devise line of your #{@model_name} model file."

--- a/lib/generators/devise_account_expireable/templates/migration.rb
+++ b/lib/generators/devise_account_expireable/templates/migration.rb
@@ -1,5 +1,0 @@
-class DeviseUpdate<%= @model_name.camelize.singularize %>ExpireFields < ActiveRecord::Migration
- def change
-  add_column :<%=@model_name.tableize%>, :expires_at, :datetime
- end
-end


### PR DESCRIPTION
I had need of this gem in a Rails 5 project that is using Devise 4.8, so I updated the dependencies and the migration to be compatible. There were a few build warnings as I built and tested the gem (like licenses and other gem metadata), so I changed some things around in the gemspec to address those build errors and warnings.